### PR TITLE
Updated polling method, cleaned up some console.logs()

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,15 @@ const fetch = require('node-fetch');
 // postgreSQL API
 const { Pool, Client } = require('pg');
 const pool = new Pool({
+  /*
   connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false }
+  ssl: { rejectUnauthorized: false }*/
+  connectionString: process.env.DATABASE_URL
 });
 pool.connect().then(console.log('PostgreSQL connected.'));
 
 //Session & Refresh token table
-const makeMangaTable = 'CREATE TABLE IF NOT EXISTS dex_tokens ( \
+const makeTokensTable = 'CREATE TABLE IF NOT EXISTS dex_tokens ( \
   da_key BIGINT PRIMARY KEY,  \
   session_token TEXT,         \
   refresh_token TEXT,         \
@@ -28,34 +30,52 @@ const makeMangaTable = 'CREATE TABLE IF NOT EXISTS dex_tokens ( \
   refresh_date BIGINT         \
   )';
 
-pool.query(makeMangaTable, (err, res) => {
+pool.query(makeTokensTable, (err, res) => {
   if (err) { console.log(err); }
   else { console.log('dex_tokens table made successfully'); }
 });
 
+//Following Table
+const makeFollowsTable = 'CREATE TABLE IF NOT EXISTS follows ( \
+  user_id TEXT,                   \
+  manga_id TEXT,                  \
+  PRIMARY KEY (user_id, manga_id) \
+  )';
+pool.query(makeFollowsTable, (err, res) => {
+  if (err) { console.log(err); }
+  else { console.log('follows table made successfully'); }
+});
+  
 
 //MagnaDex Stuff
 const { getTitleInfo, updateMangaList, getMangaUpdates, processUpdates } = require('./manga.js');
 
+async function pollUpdates(previousUrls, channel) {
+  //Continuously checks for updates every 10 minutes and sends them out.
+  const updates = await getMangaUpdates();
+  console.log(`Num of updates: ${updates.length}`);
+  const newSet = new Set();
+  for (const toEmbed of (await processUpdates(updates))) {
+    if (!previousUrls.has(toEmbed.embeds[0].url)) {
+      newSet.add(toEmbed.embeds[0].url);
+      await channel.send(toEmbed);
+    }
+  }
+  setTimeout(function(){pollUpdates(newSet, channel)}, 30000);
+}
+
 
 bot.on('ready', async () => {
   const commands = bot.guilds.cache.get(process.env.GUILD_ID).commands;
-  commands.create(addCommand);
-  commands.create(delCommand);
+  await commands.create(addCommand);
+  await commands.create(delCommand);
   console.log('Commands created');
 
   console.log("Mangadex-bot logged in");
   bot.user.setActivity('Doki Doki Literature Club', { type: 'PLAYING' });
 
-
-  setInterval(async () => {
-    const updates = await getMangaUpdates();
-    console.log('The current updates', updates);
-    let channel = bot.channels.cache.get(process.env.CHANNEL_ID);
-    for (const toEmbed of (await processUpdates(updates))) {
-      channel.send(toEmbed);
-    }
-  }, 600000);
+  const channel = bot.channels.cache.get(process.env.CHANNEL_ID);
+  pollUpdates(new Set(), channel);
 });
 
 
@@ -76,6 +96,11 @@ bot.on('interactionCreate', async interaction => {
       verb = 'deleted';
       method = 'DELETE';
     }
+    /*
+    const userId = interaction.user.id;
+    bot.channels.cache.get(process.env.CHANNEL_STAGING_ID).send({
+      content: `<@${userId}> `
+    });*/
     const res = await updateMangaList(mangaId, method, pool);
     if (res.result === 'ok') {
       await interaction.deferReply();

--- a/manga.js
+++ b/manga.js
@@ -158,8 +158,8 @@ function getTitleInfo(intOptions) {
 
 
 function getMangaUpdates() {
-  //Returns an array of all mangas that have been updated in the last 10 minutes.
-  const timeElasped = new Date(Date.now() - 600000).toISOString().split('.')[0];
+  //Returns an array of all mangas that have been updated in the last 20 minutes.
+  const timeElasped = new Date(Date.now() - 1.2e+6).toISOString().split('.')[0];
   let url = process.env.MANGADEX_URL + `/list/${process.env.LIST_ID}/feed`
     + '?translatedLanguage[]=en' + `&createdAtSince=${timeElasped}`
     ;
@@ -167,17 +167,17 @@ function getMangaUpdates() {
     method: 'GET',
     headers: { 'Content-type': 'application/json' }
   };
-  
+
   return fetch(url, options).then(async (res) => {
     const json = await res.json();
     if (json.result === 'ok') {
-      console.log("THE RESULTS BEFORE FILTERING", json);
       const toReturn = []
       const uniques = new Set();
       for (const update of json.data) {
-        if (uniques.has(update.id)) { continue; }
-        uniques.add(update.id);
-        toReturn.push(update);
+        if (!uniques.has(update.id)) {
+          uniques.add(update.id);
+          toReturn.push(update);
+        }
       }
       for (const c of toReturn) {
         console.log('Returned data items', c);
@@ -301,19 +301,19 @@ async function processUpdates(updates) {
     const scanGroup = (await getScanGroup(update)) || '';
     const authorName = (await getAuthorName(mangaData)) || '';
     const coverFileName = await getCoverFileName(mangaData);
-    const thumbnailUrl = `https://uploads.mangadex.org/covers/${mangaData.id}/${coverFileName}`;
+    const thumbnailUrl = `https://uploads.mangadex.org/covers/${mangaData?.id}/${coverFileName}`;
     const chapter = update?.attributes?.chapter || '?';
     const mangaTitle = mangaData?.attributes?.title?.en || 'Unknown Title';
     const chapterTitle = update?.attributes?.title || '';
     const embed = {
       'embeds': [{
-          'title': `Ch ${chapter} - ${mangaTitle}`,
-          'description': `${chapterTitle}\nAuthor: ${authorName}\nGroup: ${scanGroup}`,
-          'color': 16742144,
-          'footer': { 'text': 'That New New' },
-          'url': `https://mangadex.org/chapter/${update?.id}`,
-          'timestamp': update?.attributes?.createdAt,
-          'thumbnail': { 'url': thumbnailUrl }
+        'title': `Ch ${chapter} - ${mangaTitle}`,
+        'description': `${chapterTitle}\nAuthor: ${authorName}\nGroup: ${scanGroup}`,
+        'color': 16742144,
+        'footer': { 'text': 'That New New' },
+        'url': `https://mangadex.org/chapter/${update?.id}`,
+        'timestamp': update?.attributes?.createdAt,
+        'thumbnail': { 'url': thumbnailUrl }
       }]
     };
     toReturn.push(embed);


### PR DESCRIPTION
Still polls every 10 minutes, but checks for updates in the last 20. Checks against previously sent embeds, will only send if it's actually new. This is an attempt to catch mangas that should've been sent and were within the checked time frame, but for some reason weren't sent. (Heroku logs showed it just somehow skipped it)

setTimeout allows for checking to be run once when the bot comes online. 

Also added some future code for following features (postgreSQL table)